### PR TITLE
Add arguments to black command in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - pip install -r Requirements.txt
 script:
   - isort -c
-  - black --check .
+  - black --check --line-length=90 --target-version=py36 .
   - pyroma .
   - pylint --rcfile=setup.cfg collect_stata tests
   - pytest -rf --cov


### PR DESCRIPTION
The black pre-commit-hook and the call in .travis.yml used different settings, which lead to conflicts in Travis CI.