### PR TITLE
[WIP] Change write_json to accept a different data structure for the metadata argument

### DIFF
--- a/collect_stata/write_json.py
+++ b/collect_stata/write_json.py
@@ -266,11 +266,28 @@ def generate_stat(data, metadata, study):
 def write_json(data, metadata, filename, study=""):
     """Main function to write json.
 
-    Input:
-    data: pandas DataFrame (later called file_csv)
-    metadata: dict (later called file_json)
-    filename: string
-    study: string
+    TODO: this function should be able to handel a list as metadata input.
+    This list will contain a dictionary for ever variable of a dataset.
+    Example:
+        .. code-block:: python
+
+            [
+                    {
+                        "name": "variable_name",
+                        "label": "variable_label",
+                        "type": "category"
+                        "categories": {
+                            "values": [-1, 1],
+                            "labels": ["[-1] invalid", "[1] valid"],
+                        },
+                    }
+            ]
+
+    Args:
+        data: Datatable of imported data.
+        metadata: Metadata of the imported data.
+        filename: Name of the output json file.
+        study: Name of the study.
     """
 
     stat = generate_stat(data, metadata, study)


### PR DESCRIPTION
#54 changes adds a method to extract metadata of a .dta file in a different data structure.
This data structure is based on the current output of write_json.
write_json should take this input and add all further data (stats etc.) to it.
This can then directly written to a file.