### PR TITLE
Add TypedDicts to simplify type hints

### DIFF
--- a/collect_stata/__main__.py
+++ b/collect_stata/__main__.py
@@ -3,10 +3,10 @@ __author__ = "Marius Pahl"
 
 import argparse
 import logging
-import pathlib
 import sys
 import time
 from multiprocessing import Process
+from pathlib import Path
 
 from collect_stata.read_stata import StataDataExtractor
 from collect_stata.write_json import write_json
@@ -39,8 +39,8 @@ def main() -> None:
 
     args = parser.parse_args()
     study = args.study
-    input_path = pathlib.Path(args.input)
-    output_path = pathlib.Path(args.output)
+    input_path = Path(args.input)
+    output_path = Path(args.output)
     run_parallel = args.multiprocessing
 
     if args.verbose:
@@ -57,10 +57,7 @@ def main() -> None:
 
 
 def stata_to_json(
-    study_name: str,
-    input_path: pathlib.Path,
-    output_path: pathlib.Path,
-    run_parallel: bool = True,
+    study_name: str, input_path: Path, output_path: Path, run_parallel: bool = True
 ) -> None:
     """Discover files to work on and handle top level data flow.
 
@@ -95,7 +92,7 @@ def stata_to_json(
     logging.info("Duration {:.5f} seconds".format(duration))
 
 
-def _run(file: pathlib.Path, output_path: pathlib.Path, study_name: str) -> None:
+def _run(file: Path, output_path: Path, study_name: str) -> None:
     """Encapsulate data processing run with multiprocessing."""
     file_path = output_path.joinpath(file.stem).with_suffix(".json")
 

--- a/collect_stata/read_stata.py
+++ b/collect_stata/read_stata.py
@@ -3,11 +3,13 @@ __author__ = "Marius Pahl"
 
 import pathlib
 import warnings
-from typing import Dict, List, Union
+from typing import List
 
 import pandas
 import pandas.io.stata
 from pandas.api.types import is_numeric_dtype
+
+from collect_stata.types import Variable
 
 
 class StataDataExtractor:
@@ -30,7 +32,7 @@ class StataDataExtractor:
     file_name: pathlib.Path
     reader: pandas.io.stata.StataReader
     data: pandas.DataFrame
-    metadata: List[Dict[str, Union[str, Dict[str, List[Union[int, str, bool]]]]]]
+    metadata: List[Variable]
 
     def __init__(self, file_name: pathlib.Path):
         self.file_name = file_name
@@ -45,9 +47,7 @@ class StataDataExtractor:
         self.data = self.reader.read()
         self.metadata = self.get_variable_metadata()
 
-    def get_variable_metadata(
-        self
-    ) -> List[Dict[str, Union[str, Dict[str, List[Union[int, str, bool]]]]]]:
+    def get_variable_metadata(self) -> List[Variable]:
         """Gather metadata about variables in the data.
 
         Stores computed metadata in the attribute metadata.
@@ -68,7 +68,7 @@ class StataDataExtractor:
         variable_labels = self.reader.variable_labels()
         value_labels = self.reader.value_labels()
         for variable in self.reader.varlist:
-            variable_meta = dict()
+            variable_meta: Variable = Variable()
             variable_meta["name"] = variable
             variable_meta["dataset"] = dataset
             variable_meta["label"] = variable_labels.get(variable, None)

--- a/collect_stata/types.py
+++ b/collect_stata/types.py
@@ -1,0 +1,27 @@
+"""All custom type definitions for the project."""
+from typing import Dict, List, TypedDict, Union
+
+Numeric = Union[int, float]
+
+
+class Categories(TypedDict, total=False):
+    """Represent the metadata about categories of a Variable."""
+
+    values: List[Numeric]
+    missings: List[bool]
+    frequencies: List[Numeric]
+    labels: List[str]
+    labels_de: List[str]
+
+
+class Variable(TypedDict, total=False):
+    """Represent a single variable extracted from a stata file."""
+
+    study: str
+    categories: Categories
+    statistics: Dict[str, Numeric]
+    dataset: str
+    name: str
+    label: str
+    label_de: str
+    scale: str

--- a/collect_stata/write_json.py
+++ b/collect_stata/write_json.py
@@ -4,15 +4,15 @@ __author__ = "Marius Pahl"
 import json
 import logging
 import pathlib
-from collections import Counter, OrderedDict
-from typing import Any, Dict, List, Union
+from collections import Counter
+from typing import Dict, List, Union
 
 import pandas as pd
 
+from collect_stata.types import Categories, Numeric, Variable
 
-def get_categorical_frequencies(
-    elem: Dict[str, Dict[str, List[Union[int, str, bool]]]], data: pd.DataFrame
-) -> Dict[str, List[int]]:
+
+def get_categorical_frequencies(elem: Variable, data: pd.DataFrame) -> Categories:
     """Generate dict with frequencies and labels for categorical variables
 
     Input:
@@ -23,7 +23,7 @@ def get_categorical_frequencies(
     cat_dict: dict
     """
 
-    frequencies = []
+    frequencies: List[Numeric] = []
 
     value_count = data[elem["name"]].value_counts()
 
@@ -47,8 +47,7 @@ def get_categorical_frequencies(
 
 
 def get_categorical_statistics(
-    elem: Dict[str, Union[str, Union[Dict[str, List[Union[int, str, bool]]]]]],
-    data: pd.DataFrame,
+    elem: Variable, data: pd.DataFrame
 ) -> Dict[str, Union[int, float]]:
     """Generate dict with statistics for categorical variables
 
@@ -69,10 +68,7 @@ def get_categorical_statistics(
     return {"valid": valid, "invalid": invalid}
 
 
-def get_nominal_statistics(
-    elem: Dict[str, Union[str, Union[Dict[str, List[Union[int, str, bool]]]]]],
-    data: pd.DataFrame,
-) -> Dict[str, Union[int, float]]:
+def get_nominal_statistics(elem: Variable, data: pd.DataFrame) -> Dict[str, Numeric]:
     """Generate dict with statistics for nominal variables
 
     Input:
@@ -92,8 +88,7 @@ def get_nominal_statistics(
 
 
 def get_numerical_statistics(
-    elem: Dict[str, Union[str, Union[Dict[str, List[Union[int, str, bool]]]]]],
-    data: pd.DataFrame,
+    elem: Variable, data: pd.DataFrame
 ) -> Dict[str, Union[float, int]]:
     """Generate dict with statistics for numerical variables
 
@@ -127,7 +122,7 @@ def get_numerical_statistics(
 
 
 def get_univariate_statistics(
-    elem: Dict[str, Union[str, Union[Dict[str, Any]]]], data: pd.DataFrame
+    elem: Variable, data: pd.DataFrame
 ) -> Dict[str, Union[int, float]]:
     """Call function to generate statistics depending on the variable type
 
@@ -157,9 +152,7 @@ def get_univariate_statistics(
     return statistics
 
 
-def get_value_counts_and_frequencies(
-    elem: Dict[str, Dict[str, List[Union[int, str, bool]]]], data: pd.DataFrame
-) -> Dict[str, List[int]]:
+def get_value_counts_and_frequencies(elem: Variable, data: pd.DataFrame) -> Categories:
     """Call function to generate frequencies depending on the variable type
 
     Input:
@@ -170,7 +163,7 @@ def get_value_counts_and_frequencies(
     statistics: OrderedDict
     """
 
-    statistics: Dict[str, List[int]] = OrderedDict()
+    statistics: Categories = Categories()
     _scale = elem["scale"]
 
     if _scale == "cat":
@@ -180,8 +173,8 @@ def get_value_counts_and_frequencies(
 
 
 def generate_statistics(
-    data: pd.DataFrame, metadata: List[Dict[str, Any]], study: str
-) -> List[Dict[str, Union[str, Dict[str, List[Union[int, float, str, bool]]]]]]:
+    data: pd.DataFrame, metadata: List[Variable], study: str
+) -> List[Variable]:
     """Prepare statistics for every variable
 
     Input:
@@ -204,10 +197,7 @@ def generate_statistics(
 
 
 def write_json(
-    data: pd.DataFrame,
-    metadata: List[Dict[str, Union[str, Dict[str, List[Union[int, str, bool]]]]]],
-    filename: pathlib.Path,
-    study: str,
+    data: pd.DataFrame, metadata: List[Variable], filename: pathlib.Path, study: str
 ) -> None:
     """Main function to write json.
 


### PR DESCRIPTION
The dictionary structure for variable was so complex, that basic type hints were basically unreadable.
Since they were unreadable they were also not very helpful for humans.
Two TypedDict classes, `Variable` and `Categories`, are introduced to help with that.